### PR TITLE
[Firefox] - animated borders missing around cards

### DIFF
--- a/src/styles/animations/index.css
+++ b/src/styles/animations/index.css
@@ -26,7 +26,7 @@
       @apply content-[''] absolute inset-0 rounded-primary border-[1.5px] border-transparent filter contrast-[6] bg-current pointer-events-none transition-all duration-1000;
     }
     &:after {
-      background: linear-gradient(var(--angle), var(--tw-gradient-stops)) border-box;
+      background: linear-gradient(var(--angle, 0deg), var(--tw-gradient-stops)) border-box;
       @apply animate-[rotate_4s_linear_infinite] opacity-0 hover:opacity-100;
     }
   }


### PR DESCRIPTION
**Fixed bug: The border around the cards was not showing up in Firefox**

:green_circle:  My Solution:
- [According to MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@property#browser_compatibility), Firefox does not support the @property at-rule at the time of writing. This means that --angle has no default value. This means that the linear-gradient() value in the background declaration in the .animated-border:after rule would be invalid:  
  - So I added "0deg" like this:
    - `&:after {
      background: linear-gradient(var(--angle, 0deg), var(--tw-gradient-stops)) border-box;
      @apply animate-[rotate_4s_linear_infinite] opacity-0 hover:opacity-100;
    }`

  - Now the border is displaying but the animation is still not working on the Firefox browser because as stated above that Firefox does not support the @property at-rule at the time of writing, so the animation would not work since it relies on --angle being animatable


fixes #80 
 
